### PR TITLE
Add support for finishing incomplete downloads

### DIFF
--- a/lib/flickr_airlift.rb
+++ b/lib/flickr_airlift.rb
@@ -52,8 +52,8 @@ module FlickrAirlift
               download_url        = df.source
               file_to_write       = File.join(scraped_user, "#{photo_id}#{File.extname(download_url)}")
 
-              if File.exists?(file_to_write)
-                puts "** SKIPPING #{file_to_write} because it exists"
+              if File.exists?(file_to_write) && File.size(file_to_write) > 0
+                puts "** SKIPPING #{file_to_write} because it has already been downloaded"
               else
                 puts "** Downloading #{i+1}: #{photo.title} (#{size_name}) from #{download_url}"
                 File.open(file_to_write, 'wb') { |file| file.puts Net::HTTP.get_response(URI.parse(download_url)).body }
@@ -127,5 +127,9 @@ module FlickrAirlift
       data["api_token"] = auth.token
       File.open(auth_file, "w"){|f| YAML.dump(data, f) }
     end
+  end
+
+  def self.file_path_for_photo(scraped_user, photo_id)
+
   end
 end


### PR DESCRIPTION
Currently if flickr_airlift is interrupted when downloading a photo it will leave a zero byte file on the file system and then skip this photo next time it is run and so never fully download the photo.

These commits resolve this problem
